### PR TITLE
feat: dedupe import and simplify data view

### DIFF
--- a/src/pages/ViewData.jsx
+++ b/src/pages/ViewData.jsx
@@ -32,22 +32,15 @@ export default function ViewData() {
 
   const handleClearRefund = () => {
     const filtered = txns.filter(t => !String(t.status).includes('退款'))
+    filtered.sort((a, b) => new Date(b.time) - new Date(a.time))
     setTxns(filtered)
     localStorage.setItem('transactions', JSON.stringify(filtered))
   }
 
-  // 按日期分组
-  const groups = []
-  txns.forEach((txn, idx) => {
-    const date = txn.time || ''
-    let group = groups.find(g => g.date === date)
-    if (!group) {
-      group = { date, rows: [] }
-      groups.push(group)
-    }
-    group.rows.push({ ...txn, _idx: idx })
-  })
-  groups.sort((a, b) => new Date(b.date) - new Date(a.date))
+  const handleResetData = () => {
+    setTxns([])
+    localStorage.removeItem('transactions')
+  }
 
   const fields = ['time', 'merchant', 'item', 'type', 'channel', 'status', 'note']
   const headers = ['时间', '交易对方', '商品说明', '收/支', '收/付款方式', '交易状态', '备注']
@@ -55,55 +48,59 @@ export default function ViewData() {
   return (
     <div className="p-6">
       <h2 className="text-2xl font-bold mb-4">查看数据</h2>
-      <button
-        onClick={handleClearRefund}
-        className="mb-4 px-4 py-2 bg-zinc-200 hover:bg-zinc-300 rounded"
-      >
-        清除已退款数据
-      </button>
-      {groups.map(g => (
-        <div key={g.date} className="mb-6">
-          <h3 className="font-semibold mb-2">{g.date}</h3>
-          <div className="overflow-auto rounded border border-zinc-200 bg-white shadow">
-            <table className="min-w-full text-sm">
-              <thead className="bg-zinc-50">
-                <tr>
-                  {headers.map(h => (
-                    <th key={h} className="px-3 py-2 whitespace-nowrap text-left">
-                      {h}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {g.rows.map(r => (
-                  <tr key={r._idx} className="odd:bg-white even:bg-zinc-50">
-                    {fields.map(f => (
-                      <td
-                        key={f}
-                        className="px-3 py-2 whitespace-nowrap cursor-pointer"
-                        onClick={() => handleCellClick(r._idx, f)}
-                      >
-                        {editing.index === r._idx && editing.field === f ? (
-                          <input
-                            value={txns[r._idx][f] || ''}
-                            onChange={e => handleCellChange(r._idx, f, e.target.value)}
-                            onBlur={handleBlur}
-                            autoFocus
-                            className="w-full border rounded px-1"
-                          />
-                        ) : (
-                          txns[r._idx][f] || ''
-                        )}
-                      </td>
-                    ))}
-                  </tr>
+      <div className="mb-4 space-x-2">
+        <button
+          onClick={handleClearRefund}
+          className="px-4 py-2 bg-zinc-200 hover:bg-zinc-300 rounded"
+        >
+          清除已退款数据
+        </button>
+        <button
+          onClick={handleResetData}
+          className="px-4 py-2 bg-red-200 hover:bg-red-300 rounded"
+        >
+          重置数据
+        </button>
+      </div>
+      <div className="overflow-auto rounded border border-zinc-200 bg-white shadow">
+        <table className="min-w-full text-sm">
+          <thead className="bg-zinc-50">
+            <tr>
+              {headers.map(h => (
+                <th key={h} className="px-3 py-2 whitespace-nowrap text-left">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {txns.map((r, idx) => (
+              <tr key={idx} className="odd:bg-white even:bg-zinc-50">
+                {fields.map(f => (
+                  <td
+                    key={f}
+                    className="px-3 py-2 whitespace-nowrap cursor-pointer"
+                    onClick={() => handleCellClick(idx, f)}
+                  >
+                    {editing.index === idx && editing.field === f ? (
+                      <input
+                        value={txns[idx][f] || ''}
+                        onChange={e => handleCellChange(idx, f, e.target.value)}
+                        onBlur={handleBlur}
+                        autoFocus
+                        className="w-full border rounded px-1"
+                      />
+                    ) : (
+                      txns[idx][f] || ''
+                    )}
+                  </td>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- de-duplicate transactions when importing bills to avoid repeated entries
- add reset button and use a single date-sorted table on the data view page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d8680bfe08323b75dfa005fe25868