### PR TITLE
feat: add resizable table columns

### DIFF
--- a/src/components/TablePreview.jsx
+++ b/src/components/TablePreview.jsx
@@ -1,6 +1,6 @@
-export default function TablePreview({ rows = [] }) {
-  if (!rows.length) return null
+import { useState } from 'react'
 
+export default function TablePreview({ rows = [] }) {
   // 字段中英文映射
   const headerMap = {
     source: '来源',
@@ -17,6 +17,31 @@ export default function TablePreview({ rows = [] }) {
   const head = Object.keys(rows[0] || {})
   const show = rows.slice(0, 50)
 
+  // 记录每列宽度
+  const [colWidths, setColWidths] = useState({})
+
+  if (!rows.length) return null
+
+  // 拖拽调整列宽
+  const handleMouseDown = (e, key) => {
+    e.preventDefault()
+    const startX = e.clientX
+    const startWidth = e.target.parentElement.offsetWidth
+
+    const onMouseMove = e2 => {
+      const newWidth = Math.max(50, startWidth + e2.clientX - startX)
+      setColWidths(w => ({ ...w, [key]: newWidth }))
+    }
+
+    const onMouseUp = () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+  }
+
   return (
     <div className="mt-6 overflow-auto rounded-xl border border-zinc-200 bg-white shadow">
       <table className="min-w-full text-sm">
@@ -25,11 +50,16 @@ export default function TablePreview({ rows = [] }) {
             {head.map(k => (
               <th
                 key={k}
-                className={`px-3 py-2 whitespace-nowrap ${
+                style={{ width: colWidths[k], minWidth: colWidths[k] }}
+                className={`relative px-3 py-2 whitespace-nowrap border-r border-zinc-200 last:border-r-0 ${
                   k === 'merchant' || k === 'item' ? 'text-center' : 'text-left'
                 }`}
               >
                 {headerMap[k] || k}
+                <div
+                  onMouseDown={e => handleMouseDown(e, k)}
+                  className="absolute right-0 top-0 h-full w-1 cursor-col-resize bg-transparent hover:bg-blue-400"
+                ></div>
               </th>
             ))}
           </tr>
@@ -40,7 +70,8 @@ export default function TablePreview({ rows = [] }) {
               {head.map(k => (
                 <td
                   key={k}
-                  className={`px-3 py-2 whitespace-nowrap ${
+                  style={{ width: colWidths[k], minWidth: colWidths[k] }}
+                  className={`px-3 py-2 whitespace-nowrap border-r border-zinc-200 last:border-r-0 ${
                     k === 'merchant' || k === 'item' ? 'text-center' : ''
                   }`}
                 >


### PR DESCRIPTION
## Summary
- enable column width dragging in data preview table
- show vertical column separators for clearer layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d8f7de8248323b9bfbe6d748fbf2a